### PR TITLE
feat(database): add interceptors table for tools configuration [BE-01]

### DIFF
--- a/packages/database/src/migrations.ts
+++ b/packages/database/src/migrations.ts
@@ -90,6 +90,15 @@ export function ensureSchema(db: Database): void {
 			updated_at INTEGER NOT NULL
 		)
 	`);
+
+	// Create interceptors table for storing tool configurations
+	db.run(`
+		CREATE TABLE IF NOT EXISTS interceptors (
+			id TEXT PRIMARY KEY,
+			is_enabled INTEGER NOT NULL DEFAULT 0,
+			config TEXT NOT NULL
+		)
+	`);
 }
 
 export function runMigrations(db: Database): void {


### PR DESCRIPTION
## Summary
- Implements ticket BE-01 from the configurable system prompt interceptor roadmap
- Adds new database table `interceptors` to store configuration for request interception tools
- Supports flexible system prompt configuration with template and tool usage toggle

## Changes
- Added `interceptors` table to the database schema with columns:
  - `id` (TEXT, PRIMARY KEY): Unique identifier for the interceptor
  - `is_enabled` (INTEGER, NOT NULL, DEFAULT 0): Boolean flag to toggle the interceptor
  - `config` (TEXT, NOT NULL): JSON string for tool-specific configuration

## Test plan
- [x] Code passes lint checks
- [x] Code passes TypeScript type checking  
- [x] Code is properly formatted
- [ ] Run the application and verify the `interceptors` table is created
- [ ] Using a SQLite client, confirm the table has the specified columns

## Related
Part of the configurable system prompt interceptor feature implementation