### PR TITLE
BE-02: Create InterceptorRepository and Expose in DatabaseOperations

### DIFF
--- a/packages/database/src/database-operations.ts
+++ b/packages/database/src/database-operations.ts
@@ -7,6 +7,10 @@ import { ensureSchema, runMigrations } from "./migrations";
 import { resolveDbPath } from "./paths";
 import { AccountRepository } from "./repositories/account.repository";
 import { AgentPreferenceRepository } from "./repositories/agent-preference.repository";
+import {
+	type InterceptorConfig,
+	InterceptorRepository,
+} from "./repositories/interceptor.repository";
 import { OAuthRepository } from "./repositories/oauth.repository";
 import {
 	type RequestData,
@@ -34,6 +38,7 @@ export class DatabaseOperations implements StrategyStore, Disposable {
 	private strategy: StrategyRepository;
 	private stats: StatsRepository;
 	private agentPreferences: AgentPreferenceRepository;
+	private interceptor: InterceptorRepository;
 
 	constructor(dbPath?: string) {
 		const resolvedPath = dbPath ?? resolveDbPath();
@@ -59,6 +64,7 @@ export class DatabaseOperations implements StrategyStore, Disposable {
 		this.strategy = new StrategyRepository(this.db);
 		this.stats = new StatsRepository(this.db);
 		this.agentPreferences = new AgentPreferenceRepository(this.db);
+		this.interceptor = new InterceptorRepository(this.db);
 	}
 
 	setRuntimeConfig(runtime: RuntimeConfig): void {
@@ -348,6 +354,21 @@ export class DatabaseOperations implements StrategyStore, Disposable {
 
 	setBulkAgentPreferences(agentIds: string[], model: string): void {
 		this.agentPreferences.setBulkPreferences(agentIds, model);
+	}
+
+	// Interceptor operations delegated to repository
+	getInterceptorConfig(
+		id: string,
+	): { isEnabled: boolean; config: InterceptorConfig } | null {
+		return this.interceptor.getConfig(id);
+	}
+
+	setInterceptorConfig(
+		id: string,
+		isEnabled: boolean,
+		config: InterceptorConfig,
+	): void {
+		this.interceptor.setConfig(id, isEnabled, config);
 	}
 
 	close(): void {

--- a/packages/database/src/repositories/interceptor.repository.ts
+++ b/packages/database/src/repositories/interceptor.repository.ts
@@ -1,0 +1,42 @@
+import { BaseRepository } from "./base.repository";
+
+export interface InterceptorConfig {
+	promptTemplate: string;
+	toolsEnabled: boolean;
+}
+
+interface InterceptorRow {
+	id: string;
+	is_enabled: number;
+	config: string;
+}
+
+export class InterceptorRepository extends BaseRepository<InterceptorRow> {
+	getConfig(
+		id: string,
+	): { isEnabled: boolean; config: InterceptorConfig } | null {
+		const row = super.get<InterceptorRow>(
+			"SELECT id, is_enabled, config FROM interceptors WHERE id = ?",
+			[id],
+		);
+
+		if (!row) {
+			return null;
+		}
+
+		return {
+			isEnabled: row.is_enabled === 1,
+			config: JSON.parse(row.config) as InterceptorConfig,
+		};
+	}
+
+	setConfig(id: string, isEnabled: boolean, config: InterceptorConfig): void {
+		const configJson = JSON.stringify(config);
+		const isEnabledInt = isEnabled ? 1 : 0;
+
+		this.run(
+			"INSERT OR REPLACE INTO interceptors (id, is_enabled, config) VALUES (?, ?, ?)",
+			[id, isEnabledInt, configJson],
+		);
+	}
+}


### PR DESCRIPTION
## Summary
- Created new InterceptorRepository to manage the `interceptors` table
- Integrated repository into DatabaseOperations following existing patterns
- Implements storage and retrieval of tool configurations for System Prompt Interceptor feature

## Changes
- **New file**: `packages/database/src/repositories/interceptor.repository.ts`
  - Defines `InterceptorConfig` interface with `promptTemplate` and `toolsEnabled` fields
  - Implements `InterceptorRepository` extending `BaseRepository`
  - Methods: `getConfig(id)` to fetch and parse config, `setConfig(id, isEnabled, config)` to save
  
- **Modified**: `packages/database/src/database-operations.ts`
  - Added private `interceptor` property
  - Instantiated InterceptorRepository in constructor
  - Added public delegation methods: `getInterceptorConfig` and `setInterceptorConfig`

## Verification
✅ TypeScript compilation passes without errors (`bun x tsc --noEmit`)
✅ Linting and formatting applied (`bun run lint`, `bun run format`)
✅ Follows existing repository pattern and conventions

## Context
This is ticket BE-02 from the System Prompt Interceptor roadmap. It depends on BE-01 (interceptors table creation) which has already been completed.

Part of implementing a configurable System Prompt Interceptor tool that will allow users to customize the main agent's system prompt while preserving dynamic blocks.