### PR TITLE
feat(http-api): add system prompt interceptor API endpoints

### DIFF
--- a/packages/http-api/src/handlers/tools.ts
+++ b/packages/http-api/src/handlers/tools.ts
@@ -1,0 +1,73 @@
+import type { DatabaseOperations } from "@ccflare/database";
+import { BadRequest, errorResponse, jsonResponse } from "@ccflare/http-common";
+
+/**
+ * Create system prompt interceptor handlers
+ */
+export function createSystemPromptInterceptorHandler(
+	dbOps: DatabaseOperations,
+) {
+	return {
+		/**
+		 * Get system prompt interceptor configuration
+		 */
+		getSystemPromptConfig: (): Response => {
+			const config = dbOps.getInterceptorConfig("system_prompt");
+
+			// Return default configuration if none exists
+			if (!config) {
+				return jsonResponse({
+					isEnabled: false,
+					promptTemplate: "Your custom prompt here.\n\n{{env_block}}",
+					toolsEnabled: true,
+				});
+			}
+
+			return jsonResponse({
+				isEnabled: config.isEnabled,
+				promptTemplate: config.config.promptTemplate,
+				toolsEnabled: config.config.toolsEnabled,
+			});
+		},
+
+		/**
+		 * Set system prompt interceptor configuration
+		 */
+		setSystemPromptConfig: async (req: Request): Promise<Response> => {
+			try {
+				const body = await req.json();
+
+				// Validate required fields
+				if (typeof body.isEnabled !== "boolean") {
+					return errorResponse(BadRequest("isEnabled must be a boolean"));
+				}
+
+				if (typeof body.promptTemplate !== "string") {
+					return errorResponse(BadRequest("promptTemplate must be a string"));
+				}
+
+				if (typeof body.toolsEnabled !== "boolean") {
+					return errorResponse(BadRequest("toolsEnabled must be a boolean"));
+				}
+
+				// Save configuration to database
+				dbOps.setInterceptorConfig("system_prompt", body.isEnabled, {
+					promptTemplate: body.promptTemplate,
+					toolsEnabled: body.toolsEnabled,
+				});
+
+				return jsonResponse({
+					success: true,
+					isEnabled: body.isEnabled,
+					promptTemplate: body.promptTemplate,
+					toolsEnabled: body.toolsEnabled,
+				});
+			} catch (error) {
+				if (error instanceof SyntaxError) {
+					return errorResponse(BadRequest("Invalid JSON"));
+				}
+				throw error;
+			}
+		},
+	};
+}

--- a/packages/http-api/src/handlers/tools.ts
+++ b/packages/http-api/src/handlers/tools.ts
@@ -37,15 +37,27 @@ export function createSystemPromptInterceptorHandler(
 			try {
 				const body = await req.json();
 
-				// Validate required fields
+				// Validate required fields exist and have correct types
+				if (body.isEnabled === undefined || body.isEnabled === null) {
+					return errorResponse(BadRequest("isEnabled is required"));
+				}
 				if (typeof body.isEnabled !== "boolean") {
 					return errorResponse(BadRequest("isEnabled must be a boolean"));
 				}
 
+				if (body.promptTemplate === undefined || body.promptTemplate === null) {
+					return errorResponse(BadRequest("promptTemplate is required"));
+				}
 				if (typeof body.promptTemplate !== "string") {
 					return errorResponse(BadRequest("promptTemplate must be a string"));
 				}
+				if (body.promptTemplate.trim() === "") {
+					return errorResponse(BadRequest("promptTemplate cannot be empty"));
+				}
 
+				if (body.toolsEnabled === undefined || body.toolsEnabled === null) {
+					return errorResponse(BadRequest("toolsEnabled is required"));
+				}
 				if (typeof body.toolsEnabled !== "boolean") {
 					return errorResponse(BadRequest("toolsEnabled must be a boolean"));
 				}

--- a/packages/http-api/src/router.ts
+++ b/packages/http-api/src/router.ts
@@ -34,6 +34,7 @@ import {
 } from "./handlers/requests";
 import { createRequestsStreamHandler } from "./handlers/requests-stream";
 import { createStatsHandler, createStatsResetHandler } from "./handlers/stats";
+import { createSystemPromptInterceptorHandler } from "./handlers/tools";
 import type { APIContext } from "./types";
 import { errorResponse } from "./utils/http-error";
 
@@ -77,6 +78,7 @@ export class APIRouter {
 		const requestsStreamHandler = createRequestsStreamHandler();
 		const cleanupHandler = createCleanupHandler(dbOps, config);
 		const compactHandler = createCompactHandler(dbOps);
+		const toolsHandler = createSystemPromptInterceptorHandler(dbOps);
 
 		// Register routes
 		this.handlers.set("GET:/health", () => healthHandler());
@@ -148,6 +150,12 @@ export class APIRouter {
 			return bulkHandler(req);
 		});
 		this.handlers.set("GET:/api/workspaces", () => workspacesHandler());
+		this.handlers.set("GET:/api/tools/interceptors/system-prompt", () =>
+			toolsHandler.getSystemPromptConfig(),
+		);
+		this.handlers.set("POST:/api/tools/interceptors/system-prompt", (req) =>
+			toolsHandler.setSystemPromptConfig(req),
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Add GET and POST API endpoints for system prompt interceptor configuration
- Implement handlers for retrieving and updating system prompt interceptor settings
- Integrate new endpoints into the API router

## Changes
- **New file**: `packages/http-api/src/handlers/tools.ts` - Contains system prompt interceptor handlers
- **Updated**: `packages/http-api/src/router.ts` - Registers new endpoints at `/api/tools/interceptors/system-prompt`

## API Endpoints
- `GET /api/tools/interceptors/system-prompt` - Retrieve current configuration
- `POST /api/tools/interceptors/system-prompt` - Update configuration

## Test plan
- [ ] Verify GET endpoint returns default configuration when none exists
- [ ] Verify GET endpoint returns saved configuration when available
- [ ] Verify POST endpoint validates required fields (isEnabled, promptTemplate, toolsEnabled)
- [ ] Verify POST endpoint saves configuration to database
- [ ] Verify POST endpoint returns validation errors for invalid input