### PR TITLE
feat(BE-04): Implement configurable system prompt interception logic

### DIFF
--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -104,9 +104,15 @@ export async function handleProxy(
 	// 2. Prepare request body
 	const { buffer: requestBodyBuffer } = await prepareRequestBody(req);
 
-	// 3. Intercept and modify request for agent model preferences
-	const { modifiedBody, agentUsed, originalModel, appliedModel } =
-		await interceptAndModifyRequest(requestBodyBuffer, ctx.dbOps);
+	// 3. Intercept and modify request for agent model preferences and system prompt
+	const {
+		modifiedBody,
+		agentUsed,
+		originalModel,
+		appliedModel,
+		systemPromptModified,
+		toolsRemoved,
+	} = await interceptAndModifyRequest(requestBodyBuffer, ctx.dbOps);
 
 	// Use modified body if available
 	const finalBodyBuffer = modifiedBody || requestBodyBuffer;
@@ -119,6 +125,14 @@ export async function handleProxy(
 		log.info(
 			`Agent ${agentUsed} detected, model changed from ${originalModel} to ${appliedModel}`,
 		);
+	}
+
+	if (systemPromptModified) {
+		log.info("System prompt intercepted and modified");
+	}
+
+	if (toolsRemoved) {
+		log.info("Tools removed from request as per configuration");
 	}
 
 	// 4. Create request metadata with agent info


### PR DESCRIPTION
## Summary
- Extended the existing agent interceptor to add sophisticated system prompt interception capability
- Implemented template-based replacement of system prompts for main agent requests
- Added support for configurable tools removal from requests

## Implementation Details

This PR implements ticket BE-04 from the system prompt interceptor roadmap. The implementation extends the existing `interceptAndModifyRequest` function in the agent interceptor rather than creating a separate interceptor, maintaining a cleaner architecture.

### Key Features:
1. **Main Agent Detection**: Identifies main Claude Code agent requests (contains "You are Claude Code, Anthropic's official CLI for Claude.") while ignoring subagent requests (contains "You are an agent for Claude Code")
2. **Dynamic Content Preservation**: Extracts and preserves `<env>` blocks from original system prompts using regex matching
3. **Template Application**: Replaces `{{env_block}}` placeholders in configured templates with extracted environment data
4. **Tools Toggle**: Optionally removes the `tools` array from requests based on configuration
5. **Comprehensive Logging**: Added detailed logging for debugging and monitoring

## Changes Made
- Modified `packages/proxy/src/handlers/agent-interceptor.ts`:
  - Added `systemPromptModified` and `toolsRemoved` fields to `AgentInterceptResult` interface
  - Created new `applySystemPromptInterception` function
  - Extended `interceptAndModifyRequest` to call system prompt interception after agent detection
- Modified `packages/proxy/src/proxy.ts`:
  - Added logging for system prompt modifications and tools removal

## Dependencies
This PR depends on the following completed tickets:
- BE-01: Database interceptors table creation
- BE-02: InterceptorRepository implementation
- BE-03: HTTP API endpoints for system prompt interceptor

## Testing
The implementation includes robust error handling and graceful fallbacks:
- Returns original body if interceptor is disabled
- Skips interception for non-main-agent requests
- Preserves original functionality when no modifications are needed

## Verification Steps
1. Enable the interceptor via the API with a template containing `{{env_block}}`
2. Send a main agent proxy request and verify the system prompt is modified
3. Send a subagent request and verify it's NOT modified
4. Disable tools via the API and verify they're removed from main agent requests